### PR TITLE
Initial cookbook

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,0 +1,1 @@
+remote_file = "https://raw.githubusercontent.com/chef-cookbooks/community_cookbook_tools/master/delivery/project.toml"

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,19 @@
 .vagrant
-/cookbooks
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
 
 # Bundler
+Gemfile.lock
 bin/*
 .bundle/*
 
 .kitchen/
 .kitchen.local.yml
+.direnv/
+.envrc
+.ruby-version

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,24 @@
+driver:
+  name: dokken
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+
+transport:
+  name: dokken
+
+verifier:
+  name: inspec
+
+provisioner:
+  name: dokken
+  deprecations_as_errors: true
+
+platforms:
+- name: centos-7
+  driver:
+    image: dokken/centos-7
+    pid_one_command: /usr/lib/systemd/systemd
+
+suites:
+  - name: default
+    run_list:
+      - recipe[strongdm::default]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+LineLength:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+sudo: required
+dist: trusty
+
+
+addons:
+  apt:
+    sources:
+      - chef-current-trusty
+    packages:
+      - chefdk
+
+# Don't `bundle install` which takes about 1.5 mins
+install: echo 'skip bundle install'
+
+# Comment this, so we test everything, all the time
+# branches:
+#   only:
+#     - master
+
+services: docker
+
+env:
+  matrix:
+  - INSTANCE=default-centos-7
+
+before_script:
+  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+  - eval "$(chef shell-init bash)"
+  - chef --version
+  - cookstyle --version
+  - foodcritic --version
+
+script: kitchen verify ${INSTANCE}
+
+matrix:
+  include:
+    - script:
+      - chef exec delivery local all
+      env: UNIT_AND_LINT=1

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'stove'

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# strongdm cookbook
+
+This cookbook installs the [strongDM](https://www.strongdm.com) client.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: strongDM
+# Attributes:: default
+#
+# Copyright © 2018 Applause App Quality, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+default['strongdm']['version'] = '0.7.46'
+default['strongdm']['checksum'] = 'b95318713b6e313b6619d73d479566880a2210f374266a1bbe9a3f35f9338e1d'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,0 +1,17 @@
+name             'strongdm'
+maintainer       'Chris Gianelloni'
+maintainer_email 'cgianelloni@applause.com'
+license          'Apache-2.0'
+description      'Installs and configures strongDM'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '0.0.1'
+
+depends 'ark', '~> 3.1.1'
+
+%w(redhat centos scientific amazon ubuntu debian suse).each do |os|
+  supports os
+end
+
+source_url 'https://github.com/ApplauseOSS/strongdm_cookbook' if respond_to?(:source_url)
+issues_url 'https://github.com/ApplauseOSS/strongdm_cookbook/issues' if respond_to?(:issues_url)
+chef_version '>= 12.7' if respond_to?(:chef_version) # ark dependency

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook Name:: strongdm
+# Recipe:: default
+#
+# Copyright © 2018 Applause App Quality, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'ark'
+
+ver = node['strongdm']['version']
+
+ark 'sdm' do
+  action :cherry_pick
+  url "https://sdm-releases-production.s3.amazonaws.com/nightly/linux/sdmcli_#{ver}_linux_amd64.zip"
+  path '/usr/local/bin'
+  creates 'sdm'
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,41 @@
+#
+# Cookbook Name:: strongdm
+# Spec:: default
+#
+# Copyright © 2018 Applause App Quality, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe 'strongdm::default' do
+  context 'with all attributes default' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.4.1708') do |node|
+      end.converge(described_recipe)
+    end
+
+    it 'includes ark recipe' do
+      expect(chef_run).to include_recipe('ark::default')
+    end
+
+    it 'cherry-picks sdm from ZIP' do
+      expect(chef_run).to cherry_pick_ark('sdm')
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,25 @@
+#
+# Copyright © 2018 Applause App Quality, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+RSpec.configure do |config|
+  config.formatter = :documentation
+  config.color = true
+end
+
+at_exit { ChefSpec::Coverage.report! }

--- a/test/integration/default/controls/default_spec.rb
+++ b/test/integration/default/controls/default_spec.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: strongdm
+# Spec:: default
+#
+# Copyright © 2018 Applause App Quality, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+describe file('/usr/local/bin/sdm') do
+  it { should exist }
+  it { should be_readable }
+  it { should be_executable }
+end


### PR DESCRIPTION
This is the initial version of the strongdm cookbook. It is intended to be
used to install the `sdm` strongDM client. Running in daemon mode is out of
scope of this initial implmentation.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>