### PR TITLE
Use non-versioned download

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,8 +17,4 @@
 # limitations under the License.
 #
 
-default['strongdm']['version'] = '0.7.48'
-default['strongdm']['checksum'] = '729dd87c1ec4f48be4d37816cf5789c397e3b11de8bf878ab5acdc6b30485145'
-
-default['strongdm']['install_dir'] = '/opt/strongdm'
 default['strongdm']['user'] = 'strongdm'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,29 +19,12 @@
 
 include_recipe 'ark'
 
-ver = node['strongdm']['version']
-
 user node['strongdm']['user']
-
-directory "/home/#{node['strongdm']['user']}/.sdm" do
-  recursive true
-  owner node['strongdm']['user']
-  group node['strongdm']['user']
-end
-
-directory "#{node['strongdm']['install_dir']}/bin" do
-  recursive true
-  owner node['strongdm']['user']
-  group node['strongdm']['user']
-end
 
 ark 'sdm' do
   action :cherry_pick
-  url "https://sdm-releases-production.s3.amazonaws.com/nightly/linux/sdmcli_#{ver}_linux_amd64.zip"
-  path "#{node['strongdm']['install_dir']}/bin"
+  url 'https://app.strongdm.com/releases/cli/linux'
+  path Chef::Config['file_cache_path']
+  extension 'zip'
   creates 'sdm'
-end
-
-link '/usr/local/bin/sdm' do
-  to "#{node['strongdm']['install_dir']}/bin/sdm"
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -34,20 +34,8 @@ describe 'strongdm::default' do
       expect(chef_run).to create_user('strongdm')
     end
 
-    it 'creates .sdm directory' do
-      expect(chef_run).to create_directory('/home/strongdm/.sdm')
-    end
-
-    it 'creates /opt/strongdm/bin directory' do
-      expect(chef_run).to create_directory('/opt/strongdm/bin')
-    end
-
     it 'cherry-picks sdm from ZIP' do
       expect(chef_run).to cherry_pick_ark('sdm')
-    end
-
-    it 'creates /usr/local/bin/sdm symlink' do
-      expect(chef_run).to create_link('/usr/local/bin/sdm')
     end
 
     it 'converges successfully' do


### PR DESCRIPTION
Switch from using the versioned download from S3 directly to using the URL
redirection from documentation. This allows for automatically updating the
binary, which is a requirement from upstream.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>