### PR TITLE
Self-registering server recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vagrant
 Berksfile.lock
+berks-cookbooks
 *~
 *#
 .#*

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,5 +1,7 @@
 driver:
   name: dokken
+  hostname: dokken.local
+  privileged: true # systemd, docker, and sysctl, oh my!
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport:
@@ -13,12 +15,29 @@ provisioner:
   deprecations_as_errors: true
 
 platforms:
-- name: centos-7
-  driver:
-    image: dokken/centos-7
-    pid_one_command: /usr/lib/systemd/systemd
+  - name: centos-7
+    driver:
+      image: dokken/centos-7
+      pid_one_command: /usr/lib/systemd/systemd
+      cap_add:
+        - SYS_ADMIN
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
 suites:
   - name: default
     run_list:
       - recipe[strongdm::default]
+  - name: gateway
+    run_list:
+      - recipe[strongdm::gateway]
+    attributes:
+      strongdm:
+        admin_token: CHANGEME
+  - name: server
+    run_list:
+      - recipe[openssh::default]
+      - recipe[strongdm::server]
+    attributes:
+      strongdm:
+        admin_token: CHANGEME

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
 source 'https://supermarket.chef.io'
 
+cookbook 'openssh', '~> 2.6'
+
 metadata

--- a/README.md
+++ b/README.md
@@ -1,3 +1,34 @@
 # strongdm cookbook
 
-This cookbook installs the [strongDM](https://www.strongdm.com) client.
+[![Cookbook Version](http://img.shields.io/cookbook/v/strongdm.svg)](https://supermarket.getchef.com/cookbooks/strongdm)
+[![Build Status](https://secure.travis-ci.org/ApplauseOSS/cookbook-strongdm.svg?branch=master)](http://travis-ci.org/ApplauseOSS/strongdm_cookbook)
+
+## Description
+
+This cookbook fetches the [strongDM](https://www.strongdm.com) client into
+the Chef file cache, for use during a Chef run. It includes recipes for
+gateways and SSH servers to self-register.
+
+## Recipes
+
+### default
+
+Fetches the `sdm` client from strongDM and puts it into the Chef file cache.
+Also, creates a `strongdm` local user for use by other recipes.
+
+### gateway
+
+Automatically registers a host as a strongDM gateway relay. This requires the
+user to provide an admin token which has the following permissions:
+
+- relay:create
+
+### server
+
+Automatically registers a host as a strongDM server relay. This requires the
+user to provide an admin token which has the following permissions:
+
+- datasource:create
+- datasource:grant
+- datasource:list
+- role:list

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,9 +20,13 @@
 # Set this however you see fit
 default['strongdm']['admin_token'] = nil
 
+# Installation user
 default['strongdm']['user'] = 'strongdm'
 
 # gateway/relay configuration
 default['strongdm']['gateway_port'] = 5000
 default['strongdm']['gateway_bind_address'] = '0.0.0.0'
 default['strongdm']['gateway_bind_port'] = 5000
+
+# SSH roles to grant
+default['strongdm']['default_grant_roles'] = []

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,0 +1,57 @@
+#
+# Cookbook Name:: strongdm
+# Recipe:: server
+#
+# Copyright © 2018 Applause App Quality, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'strongdm::default'
+
+execute 'sdm-login-with-admin-token' do
+  command './sdm login'
+  cwd Chef::Config['file_cache_path']
+  environment('SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'])
+  creates '/root/.sdm/auth.json'
+end
+
+execute 'sdm-admin-add-servers' do
+  command "./sdm admin servers add -p #{node['fqdn']} #{node['strongdm']['user']}@#{node['ipaddress']}"
+  cwd Chef::Config['file_cache_path']
+  environment('SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'])
+  not_if "#{Chef::Config['file_cache_path']}/sdm admin servers list | grep #{node['fqdn']}"
+end
+
+directory '/opt/strongdm/.ssh' do
+  recursive true
+  owner node['strongdm']['user']
+  group node['strongdm']['user']
+  mode 0700
+  notifies :run, 'execute[sdm-ssh-pubkey]', :immediately
+end
+
+execute 'sdm-ssh-pubkey' do
+  command "./sdm ssh pubkey #{node['fqdn']} | tee -a /opt/strongdm/.ssh/authorized_keys"
+  action :nothing
+  cwd Chef::Config['file_cache_path']
+  environment('SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'])
+end
+
+node['strongdm']['default_grant_roles'].each do |role|
+  execute "sdm-admin-roles-grant-#{role}" do
+    command "./sdm admin roles grant #{node['fqdn']} #{role}"
+    cwd Chef::Config['file_cache_path']
+    environment('SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'])
+  end
+end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,0 +1,50 @@
+#
+# Cookbook Name:: strongdm
+# Spec:: server
+#
+# Copyright © 2018 Applause App Quality, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe 'strongdm::server' do
+  context 'with all attributes default' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.4.1708') do
+        stub_command(/sdm admin servers list/).and_return(false)
+      end.converge(described_recipe)
+    end
+
+    it 'runs execute[sdm-login-with-admin-token]' do
+      expect(chef_run).to run_execute('sdm-login-with-admin-token')
+    end
+
+    it 'runs execute[sdm-admin-add-servers]' do
+      expect(chef_run).to run_execute('sdm-admin-add-servers')
+    end
+
+    it 'creates /opt/strongdm/.ssh' do
+      expect(chef_run).to create_directory('/opt/strongdm/.ssh')
+    end
+
+    it 'does not run execute[sdm-ssh-pubkey]' do
+      expect(chef_run.execute('sdm-ssh-pubkey')).to do_nothing
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
Registers a server as a SSH datasource using a given SDM admin key which has
rights to perform the necessary actions.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>