### PR TITLE
Use FQDN for gateway name

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -25,7 +25,7 @@ module StrongDM
         'relay',
         type == 'relay' ? 'create' : 'create-gateway',
         '--name',
-        node['hostname'],
+        node['fqdn'],
         "#{node['ipaddress']}:#{node['strongdm']['gateway_port']}",
         "#{node['strongdm']['gateway_bind_address']}:#{node['strongdm']['gateway_bind_port']}",
         'env' => {


### PR DESCRIPTION
Use the FQDN instead of hostname when registering a gateway or relay.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>