### PR TITLE
Trigger removal of /root/.sdm

### DIFF
--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -44,5 +44,11 @@ execute 'sdm-install-gateway' do
       }
     end
   )
-  creates '/opt/strongdm/bin/sdm'
+  creates '/etc/systemd/system/sdm-proxy.service'
+  notifies :delete, 'directory[/root/.sdm]', :immediately
+end
+
+directory '/root/.sdm' do
+  action :nothing
+  recursive true
 end

--- a/spec/gateway_spec.rb
+++ b/spec/gateway_spec.rb
@@ -34,6 +34,11 @@ describe 'strongdm::gateway' do
       expect(chef_run).to run_execute('sdm-install-gateway')
     end
 
+    it 'triggers removal of /root/.sdm' do
+      expect(chef_run.directory('/root/.sdm')).to do_nothing
+      expect(chef_run.execute('sdm-install-gateway')).to notify('directory[/root/.sdm]')
+    end
+
     it 'converges successfully' do
       expect { chef_run }.to_not raise_error
     end


### PR DESCRIPTION
Remove the /root/.sdm directory, as we shouldn't need it and we don't need
to leave the shared key on the hosts.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>