### PR TITLE
Set correct owner on authorized_keys

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -46,6 +46,12 @@ execute 'sdm-ssh-pubkey' do
   action :nothing
   cwd Chef::Config['file_cache_path']
   environment('SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'])
+  creates '/opt/strongdm/.ssh/authorized_keys'
+end
+
+file '/opt/strongdm/.ssh/authorized_keys' do
+  owner node['strongdm']['user']
+  group node['strongdm']['user']
 end
 
 node['strongdm']['default_grant_roles'].each do |role|

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -39,6 +39,10 @@ describe 'strongdm::server' do
       expect(chef_run).to create_directory('/opt/strongdm/.ssh')
     end
 
+    it 'creates /opt/strongdm/.ssh/authorized_keys' do
+      expect(chef_run).to create_file('/opt/strongdm/.ssh/authorized_keys')
+    end
+
     it 'does not run execute[sdm-ssh-pubkey]' do
       expect(chef_run.execute('sdm-ssh-pubkey')).to do_nothing
     end


### PR DESCRIPTION
Ensure the `/opt/strongdm/.ssh/authorized_keys` file has correct owner.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>