### PR TITLE
Create sdm helper to locate binary

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -21,7 +21,7 @@ module StrongDM
   module Helpers
     def sdm_relay_token(type = 'gateway')
       token = Mixlib::ShellOut.new(
-        "#{Chef::Config['file_cache_path']}/sdm",
+        sdm,
         'relay',
         type == 'relay' ? 'create' : 'create-gateway',
         '--name',
@@ -37,7 +37,11 @@ module StrongDM
       Mixlib::ShellOut.new('rm -f /root/.sdm/*').run_command
       token.stdout.chomp
     end
+
+    def sdm
+      return "#{Chef::Config['file_cache_path']}/sdm" if lazy { ::File.exist?("#{Chef::Config['file_cache_path']}/sdm") }
+      # assume we're in the PATH
+      'sdm'
+    end
   end
 end
-
-Chef::Resource::RubyBlock.send(:include, StrongDM::Helpers)

--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -19,8 +19,10 @@
 
 include_recipe 'strongdm::default'
 
-relay_token = ''
+Chef::Resource::RubyBlock.send(:include, StrongDM::Helpers)
+Chef::Resource::Execute.send(:include, StrongDM::Helpers)
 
+relay_token = ''
 ruby_block 'get-relay-token' do
   block do
     relay_token = sdm_relay_token
@@ -28,7 +30,7 @@ ruby_block 'get-relay-token' do
 end
 
 execute 'sdm-install-gateway' do
-  command "#{Chef::Config['file_cache_path']}/sdm install --relay"
+  command "#{sdm} install --relay"
   environment(
     lazy do
       {

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -19,18 +19,18 @@
 
 include_recipe 'strongdm::default'
 
+Chef::Resource::Execute.send(:include, StrongDM::Helpers)
+
 execute 'sdm-login-with-admin-token' do
-  command './sdm login'
-  cwd Chef::Config['file_cache_path']
+  command "#{sdm} login"
   environment('SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'])
   creates '/root/.sdm/auth.json'
 end
 
 execute 'sdm-admin-add-servers' do
-  command "./sdm admin servers add -p #{node['fqdn']} #{node['strongdm']['user']}@#{node['ipaddress']}"
-  cwd Chef::Config['file_cache_path']
+  command "#{sdm} admin servers add -p #{node['fqdn']} #{node['strongdm']['user']}@#{node['ipaddress']}"
   environment('SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'])
-  not_if "#{Chef::Config['file_cache_path']}/sdm admin servers list | grep #{node['fqdn']}"
+  not_if "#{sdm} admin servers list | grep #{node['fqdn']}"
 end
 
 directory '/opt/strongdm/.ssh' do
@@ -42,9 +42,8 @@ directory '/opt/strongdm/.ssh' do
 end
 
 execute 'sdm-ssh-pubkey' do
-  command "./sdm ssh pubkey #{node['fqdn']} | tee -a /opt/strongdm/.ssh/authorized_keys"
+  command "#{sdm} ssh pubkey #{node['fqdn']} | tee -a /opt/strongdm/.ssh/authorized_keys"
   action :nothing
-  cwd Chef::Config['file_cache_path']
   environment('SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'])
   creates '/opt/strongdm/.ssh/authorized_keys'
 end
@@ -56,8 +55,7 @@ end
 
 node['strongdm']['default_grant_roles'].each do |role|
   execute "sdm-admin-roles-grant-#{role}" do
-    command "./sdm admin roles grant #{node['fqdn']} #{role}"
-    cwd Chef::Config['file_cache_path']
+    command "#{sdm} admin roles grant #{node['fqdn']} #{role}"
     environment('SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'])
   end
 end


### PR DESCRIPTION
Create a helper to locate the `sdm` binary, so we can support both a gateway
and a server on the same host, easily.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>