### PR TITLE
Create relay recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,9 @@ default['strongdm']['user'] = 'strongdm'
 default['strongdm']['gateway_port'] = 5000
 default['strongdm']['gateway_bind_address'] = '0.0.0.0'
 default['strongdm']['gateway_bind_port'] = 5000
+default['strongdm']['relay_port'] = 5000
+default['strongdm']['relay_bind_address'] = '0.0.0.0'
+default['strongdm']['relay_bind_port'] = 5000
 
 # SSH roles to grant
 default['strongdm']['default_grant_roles'] = []

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,15 +19,15 @@
 
 module StrongDM
   module Helpers
-    def sdm_relay_token(type = 'gateway')
+    def sdm_relay_token(type = 'relay')
       token = Mixlib::ShellOut.new(
         sdm,
         'relay',
-        type == 'relay' ? 'create' : 'create-gateway',
+        type == 'gateway' ? 'create-gateway' : 'create',
         '--name',
         node['fqdn'],
-        "#{node['ipaddress']}:#{node['strongdm']['gateway_port']}",
-        "#{node['strongdm']['gateway_bind_address']}:#{node['strongdm']['gateway_bind_port']}",
+        "#{node['ipaddress']}:#{node['strongdm']["#{type}_port"]}",
+        "#{node['strongdm']["#{type}_bind_address"]}:#{node['strongdm']["#{type}_bind_port"]}",
         'env' => {
           'SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'],
         }

--- a/recipes/relay.rb
+++ b/recipes/relay.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: strongdm
-# Recipe:: gateway
+# Recipe:: relay
 #
 # Copyright © 2018 Applause App Quality, Inc.
 #
@@ -25,11 +25,11 @@ Chef::Resource::Execute.send(:include, StrongDM::Helpers)
 relay_token = ''
 ruby_block 'get-relay-token' do
   block do
-    relay_token = sdm_relay_token('gateway')
+    relay_token = sdm_relay_token('relay')
   end
 end
 
-execute 'sdm-install-gateway' do
+execute 'sdm-install-relay' do
   command "#{sdm} install --relay"
   environment(
     lazy do

--- a/spec/relay_spec.rb
+++ b/spec/relay_spec.rb
@@ -1,0 +1,46 @@
+#
+# Cookbook Name:: strongdm
+# Spec:: relay
+#
+# Copyright © 2018 Applause App Quality, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+
+describe 'strongdm::relay' do
+  context 'with all attributes default' do
+    cached(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.4.1708') do |node|
+      end.converge(described_recipe)
+    end
+
+    it 'runs ruby_block[get-relay-token]' do
+      expect(chef_run).to run_ruby_block('get-relay-token')
+    end
+
+    it 'runs execute[sdm-install-relay]' do
+      expect(chef_run).to run_execute('sdm-install-relay')
+    end
+
+    it 'triggers removal of /root/.sdm' do
+      expect(chef_run.directory('/root/.sdm')).to do_nothing
+      expect(chef_run.execute('sdm-install-relay')).to notify('directory[/root/.sdm]')
+    end
+
+    it 'converges successfully' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
Adds a relay recipe and makes it the default for `sdm_relay_token` library
call, as it's the default in the `sdm` tool.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>