### PR TITLE
Write out SSH authorized_keys at registration

### DIFF
--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -43,10 +43,6 @@ describe 'strongdm::server' do
       expect(chef_run).to create_file('/opt/strongdm/.ssh/authorized_keys')
     end
 
-    it 'does not run execute[sdm-ssh-pubkey]' do
-      expect(chef_run.execute('sdm-ssh-pubkey')).to do_nothing
-    end
-
     it 'converges successfully' do
       expect { chef_run }.to_not raise_error
     end


### PR DESCRIPTION
Switch to writing out the authorized_keys file at SSH server registration.
This prevents an issue where the public key isn't always fetched.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>