### PR TITLE
Use marker file for server grants

### DIFF
--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -35,12 +35,20 @@ describe 'strongdm::server' do
       expect(chef_run).to run_execute('sdm-admin-add-servers')
     end
 
+    it 'creates /opt/strongdm/.sdm' do
+      expect(chef_run).to create_directory('/opt/strongdm/.sdm')
+    end
+
     it 'creates /opt/strongdm/.ssh' do
       expect(chef_run).to create_directory('/opt/strongdm/.ssh')
     end
 
     it 'creates /opt/strongdm/.ssh/authorized_keys' do
       expect(chef_run).to create_file('/opt/strongdm/.ssh/authorized_keys')
+    end
+
+    it 'creates /opt/strongdm/.sdm/roles' do
+      expect(chef_run).to create_file('/opt/strongdm/.sdm/roles')
     end
 
     it 'converges successfully' do


### PR DESCRIPTION
Write out a marker file listing the granted roles (from Chef, not strongDM) to
use as a subscribes trigger to granting roles.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>