### PR TITLE
Remove sdm login for server recipe

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -21,11 +21,6 @@ include_recipe 'strongdm::default'
 
 Chef::Resource::Execute.send(:include, StrongDM::Helpers)
 
-execute 'sdm-login-with-admin-token' do
-  command "#{sdm} login"
-  environment('SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'])
-end
-
 directory '/opt/strongdm/.sdm' do
   recursive true
   owner node['strongdm']['user']

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -27,10 +27,6 @@ describe 'strongdm::server' do
       end.converge(described_recipe)
     end
 
-    it 'runs execute[sdm-login-with-admin-token]' do
-      expect(chef_run).to run_execute('sdm-login-with-admin-token')
-    end
-
     it 'runs execute[sdm-admin-add-servers]' do
       expect(chef_run).to run_execute('sdm-admin-add-servers')
     end


### PR DESCRIPTION
It's not necessary to `sdm login` when using an admin token.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>