### PR TITLE
Configure gateway/relay advertise address

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,12 +24,14 @@ default['strongdm']['admin_token'] = nil
 default['strongdm']['user'] = 'strongdm'
 
 # gateway/relay configuration
-default['strongdm']['gateway_port'] = 5000
+default['strongdm']['gateway_advertise_address'] = node['ipaddress']
 default['strongdm']['gateway_bind_address'] = '0.0.0.0'
 default['strongdm']['gateway_bind_port'] = 5000
-default['strongdm']['relay_port'] = 5000
+default['strongdm']['gateway_port'] = 5000
+default['strongdm']['relay_advertise_address'] = node['ipaddress']
 default['strongdm']['relay_bind_address'] = '0.0.0.0'
 default['strongdm']['relay_bind_port'] = 5000
+default['strongdm']['relay_port'] = 5000
 
 # SSH roles to grant
 default['strongdm']['default_grant_roles'] = []

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -26,7 +26,7 @@ module StrongDM
         type == 'gateway' ? 'create-gateway' : 'create',
         '--name',
         node['fqdn'],
-        "#{node['ipaddress']}:#{node['strongdm']["#{type}_port"]}",
+        "#{node['strongdm']["#{type}_advertise_address"]}:#{node['strongdm']["#{type}_port"]}",
         "#{node['strongdm']["#{type}_bind_address"]}:#{node['strongdm']["#{type}_bind_port"]}",
         'env' => {
           'SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'],


### PR DESCRIPTION
Support setting the advertise address for configuring relays and gateways.
This is required for nodes running behind a NAT.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>