### PR TITLE
Create install custom resource

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,4 @@
 LineLength:
   Enabled: false
+Metrics/ParameterLists:
+  Max: 7

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -19,18 +19,19 @@
 
 module StrongDM
   module Helpers
-    def sdm_relay_token(type = 'relay')
+    def sdm_relay_token(admin_token, name, type = 'relay', ip = nil, port = 5000, bind_ip = '0.0.0.0', bind_port = 5000)
+      return nil if admin_token.nil?
+      ip = node['ipaddress'] if ip.nil?
+      name = node['fqdn'] if name.nil?
       token = Mixlib::ShellOut.new(
         sdm,
         'relay',
         type == 'gateway' ? 'create-gateway' : 'create',
         '--name',
-        node['fqdn'],
-        "#{node['strongdm']["#{type}_advertise_address"]}:#{node['strongdm']["#{type}_port"]}",
-        "#{node['strongdm']["#{type}_bind_address"]}:#{node['strongdm']["#{type}_bind_port"]}",
-        'env' => {
-          'SDM_ADMIN_TOKEN' => node['strongdm']['admin_token'],
-        }
+        name,
+        "#{ip}:#{port}",
+        "#{bind_ip}:#{bind_port}",
+        'environment' => { 'SDM_ADMIN_TOKEN' => admin_token }
       )
       token.run_command
       # Remove temporary admin credentials
@@ -38,6 +39,15 @@ module StrongDM
       token.stdout.chomp
     end
 
+    def sdm_gid(user)
+      Mixlib::ShellOut.new("getent passwd #{user}").run_command.stdout.split(':')[3].chomp
+    end
+
+    def sdm_uid(user)
+      Mixlib::ShellOut.new("getent passwd #{user}").run_command.stdout.split(':')[2].chomp
+    end
+
+    # Finds the "sdm" binary
     def sdm
       return "#{Chef::Config['file_cache_path']}/sdm" if lazy { ::File.exist?("#{Chef::Config['file_cache_path']}/sdm") }
       # assume we're in the PATH

--- a/recipes/relay.rb
+++ b/recipes/relay.rb
@@ -19,38 +19,12 @@
 
 include_recipe 'strongdm::default'
 
-Chef::Resource::RubyBlock.send(:include, StrongDM::Helpers)
-Chef::Resource::Execute.send(:include, StrongDM::Helpers)
-
-relay_token = ''
-ruby_block 'get-relay-token' do
-  block do
-    relay_token = sdm_relay_token('relay')
-  end
-end
-
-execute 'sdm-install-relay' do
-  command "#{sdm} install --relay"
-  environment(
-    lazy do
-      {
-        'SUDO_GID' => Mixlib::ShellOut.new("getent passwd #{node['strongdm']['user']}").run_command.stdout.split(':')[3],
-        'SUDO_UID' => Mixlib::ShellOut.new("getent passwd #{node['strongdm']['user']}").run_command.stdout.split(':')[2],
-        'SUDO_USER' => node['strongdm']['user'],
-        'HOME' => '/root',
-        'LOGNAME' => 'root',
-        'UID' => '0',
-        'USER' => 'root',
-        'USERNAME' => 'root',
-        'SDM_RELAY_TOKEN' => relay_token,
-      }
-    end
-  )
-  creates '/etc/systemd/system/sdm-proxy.service'
-  notifies :delete, 'directory[/root/.sdm]', :immediately
-end
-
-directory '/root/.sdm' do
-  action :nothing
-  recursive true
+strongdm_install node['fqdn'] do
+  advertise_address node['strongdm']['relay_advertise_address']
+  bind_address node['strongdm']['relay_bind_address']
+  bind_port node['strongdm']['relay_bind_port']
+  port node['strongdm']['relay_port']
+  user node['strongdm']['user']
+  type 'relay'
+  action :create
 end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -1,0 +1,75 @@
+#
+# Cookbook Name:: strongdm
+# Resource:: install
+#
+# Copyright © 2018 Applause App Quality, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property :admin_token, [NilClass, String], default: nil
+property :advertise_address, [NilClass, String], default: nil
+property :bind_address, String, default: '0.0.0.0'
+property :bind_port, [String, Integer], default: 5000
+property :instance_name, String, name_property: true
+property :port, [String, Integer], default: 5000
+property :relay_token, [NilClass, String], default: nil
+property :type, [String, Array], default: 'relay'
+property :user, [String, Integer], default: 'strongdm'
+
+action :create do
+  admin_token = new_resource.admin_token ? new_resource.admin_token : node['strongdm']['admin_token']
+  ip = new_resource.advertise_address ? new_resource.advertise_address : node.run_state['ipaddress']
+
+  execute "sdm install #{new_resource.type}" do
+    command "#{sdm} install --relay"
+    environment(
+      lazy do
+        {
+          'SUDO_GID' => sdm_gid(new_resource.user),
+          'SUDO_UID' => sdm_uid(new_resource.user),
+          'SUDO_USER' => new_resource.user,
+          'HOME' => '/root',
+          'LOGNAME' => 'root',
+          'UID' => '0',
+          'USER' => 'root',
+          'USERNAME' => 'root',
+          'SDM_RELAY_TOKEN' => if new_resource.relay_token
+                                 new_resource.relay_token
+                               else
+                                 sdm_relay_token(
+                                   admin_token,
+                                   new_resource.instance_name,
+                                   new_resource.type,
+                                   ip,
+                                   new_resource.port,
+                                   new_resource.bind_address,
+                                   new_resource.bind_port
+                                 )
+                               end,
+        }
+      end
+    )
+    creates '/etc/systemd/system/sdm-proxy.service'
+    notifies :delete, 'directory[/root/.sdm]', :immediately
+  end
+
+  directory '/root/.sdm' do
+    action :nothing
+    recursive true
+  end
+end
+
+action_class do
+  include StrongDM::Helpers
+end

--- a/spec/gateway_spec.rb
+++ b/spec/gateway_spec.rb
@@ -26,17 +26,10 @@ describe 'strongdm::gateway' do
       end.converge(described_recipe)
     end
 
-    it 'runs ruby_block[get-relay-token]' do
-      expect(chef_run).to run_ruby_block('get-relay-token')
-    end
-
-    it 'runs execute[sdm-install-gateway]' do
-      expect(chef_run).to run_execute('sdm-install-gateway')
-    end
-
-    it 'triggers removal of /root/.sdm' do
-      expect(chef_run.directory('/root/.sdm')).to do_nothing
-      expect(chef_run.execute('sdm-install-gateway')).to notify('directory[/root/.sdm]')
+    it 'creates sdm gateway install' do
+      expect(chef_run).to create_strongdm_install('fauxhai.local').with(
+        type: 'gateway'
+      )
     end
 
     it 'converges successfully' do

--- a/test/integration/gateway/controls/gateway_spec.rb
+++ b/test/integration/gateway/controls/gateway_spec.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: strongdm
-# Spec:: relay
+# Spec:: gateway
 #
 # Copyright © 2018 Applause App Quality, Inc.
 #
@@ -17,23 +17,23 @@
 # limitations under the License.
 #
 
-require 'spec_helper'
+describe file('/usr/local/bin/sdm') do
+  it { should exist }
+  it { should be_readable }
+  it { should be_executable }
+  it { should be_symlink }
+  its('link_path') { should eq '/opt/strongdm/bin/sdm' }
+end
 
-describe 'strongdm::relay' do
-  context 'with all attributes default' do
-    cached(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'centos', version: '7.4.1708') do |node|
-      end.converge(described_recipe)
-    end
+describe file('/etc/sysconfig/sdm-proxy') do
+  it { should exist }
+  it { should be_readable }
+  its('owner') { should eq 'strongdm' }
+  its('content') { should include 'SDM_RELAY_TOKEN=' }
+end
 
-    it 'creates sdm relay install' do
-      expect(chef_run).to create_strongdm_install('fauxhai.local').with(
-        type: 'relay'
-      )
-    end
-
-    it 'converges successfully' do
-      expect { chef_run }.to_not raise_error
-    end
-  end
+describe service('sdm-proxy') do
+  it { should be_installed }
+  it { should be_enabled }
+  it { should be_running }
 end


### PR DESCRIPTION
Create a sdm_install custom resource to be used to create a gateway or relay
and use the resource in our recipes. This is the first step in moving this
cookbook into a reusable library.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>