### PR TITLE
Create server custom resource

### DIFF
--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -25,6 +25,6 @@ strongdm_install node['fqdn'] do
   bind_address node['strongdm']['gateway_bind_address']
   bind_port node['strongdm']['gateway_bind_port']
   port node['strongdm']['gateway_port']
-  user node['strongdm']['user']
+  user_name node['strongdm']['user']
   action :create
 end

--- a/recipes/relay.rb
+++ b/recipes/relay.rb
@@ -24,7 +24,7 @@ strongdm_install node['fqdn'] do
   bind_address node['strongdm']['relay_bind_address']
   bind_port node['strongdm']['relay_bind_port']
   port node['strongdm']['relay_port']
-  user node['strongdm']['user']
+  user_name node['strongdm']['user']
   type 'relay'
   action :create
 end

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -25,20 +25,25 @@ property :instance_name, String, name_property: true
 property :port, [String, Integer], default: 5000
 property :relay_token, [NilClass, String], default: nil
 property :type, [String, Array], default: 'relay'
-property :user, [String, Integer], default: 'strongdm'
+property :user_name, [String, Integer], default: 'strongdm'
 
 action :create do
   admin_token = new_resource.admin_token ? new_resource.admin_token : node['strongdm']['admin_token']
   ip = new_resource.advertise_address ? new_resource.advertise_address : node.run_state['ipaddress']
+
+  user new_resource.user_name do
+    home home_dir
+    manage_home true
+  end
 
   execute "sdm install #{new_resource.type}" do
     command "#{sdm} install --relay"
     environment(
       lazy do
         {
-          'SUDO_GID' => sdm_gid(new_resource.user),
-          'SUDO_UID' => sdm_uid(new_resource.user),
-          'SUDO_USER' => new_resource.user,
+          'SUDO_GID' => sdm_gid(new_resource.user_name),
+          'SUDO_UID' => sdm_uid(new_resource.user_name),
+          'SUDO_USER' => new_resource.user_name,
           'HOME' => '/root',
           'LOGNAME' => 'root',
           'UID' => '0',

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -1,0 +1,109 @@
+#
+# Cookbook Name:: strongdm
+# Resource:: server
+#
+# Copyright © 2018 Applause App Quality, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+property :admin_token, [NilClass, String]
+property :advertise_address, [NilClass, String]
+property :granted_roles, [NilClass, Array, String]
+property :home_dir, [NilClass, String]
+property :instance_name, String, name_property: true
+property :user_name, [String, Integer], default: 'strongdm'
+
+action :create do
+  admin_token = new_resource.admin_token ? new_resource.admin_token : node['strongdm']['admin_token']
+  ip = new_resource.advertise_address ? new_resource.advertise_address : node.run_state['ipaddress']
+  ### TODO: make this pick the correct location
+  home_dir = new_resource.home_dir ? new_resource.home_dir : "/home/#{new_resource.user_name}"
+  roles = new_resource.granted_roles ? new_resource.granted_roles : [*node['strongdm']['default_grant_roles']]
+
+  user new_resource.user_name do
+    home home_dir
+    manage_home true
+  end
+
+  directory '/opt/strongdm/.sdm' do
+    recursive true
+    owner new_resource.user_name
+    group new_resource.user_name
+    mode 0700
+  end
+
+  directory "#{home_dir}/.ssh" do
+    recursive true
+    owner new_resource.user_name
+    group new_resource.user_name
+    mode 0700
+  end
+
+  pubkey = 'DO-NOT-MATCH'
+  ruby_block 'register-server' do
+    block do
+      server = Mixlib::ShellOut.new(
+        sdm, 'admin', 'servers', 'add', '-p',
+        new_resource.instance_name,
+        "#{new_resource.user_name}@#{ip}",
+        'environment' => { 'SDM_ADMIN_TOKEN' => admin_token }
+      )
+      server.run_command
+      pubkey = server.stdout.chomp
+      Chef::Application.fatal!('Unable to fetch public key from strongDM') if pubkey.empty?
+      keyfile = ::File.new("#{home_dir}/.ssh/authorized_keys", 'a')
+      keyfile.write(pubkey)
+      keyfile.close
+    end
+    notifies :delete, "file[#{home_dir}/.sdm/roles]", :immediately
+    not_if do
+      tester = Mixlib::ShellOut.new(
+        sdm, 'admin', 'servers', 'list',
+        'environment' => { 'SDM_ADMIN_TOKEN' => admin_token }
+      )
+      if ::File.exist?("#{home_dir}/.ssh/authorized_keys") &&
+         !::File.readlines("#{home_dir}/.ssh/authorized_keys").grep(/#{pubkey}/).empty?
+        true
+      else
+        tester.run_command
+        true if tester.exitstatus == 0 && tester.stdout.chomp.include?(node['fqdn'])
+      end
+    end
+  end
+
+  file "#{home_dir}/.ssh/authorized_keys" do
+    owner new_resource.user_name
+    group new_resource.user_name
+  end
+
+  file "#{home_dir}/.sdm/roles" do
+    content roles.sort.join("\n")
+    owner new_resource.user_name
+    group new_resource.user_name
+  end
+
+  roles.sort.each do |role|
+    execute "grant-strongdm-role-#{role}" do
+      command "#{sdm} admin roles grant #{new_resource.instance_name} #{role}"
+      environment('SDM_ADMIN_TOKEN' => admin_token)
+      action :nothing
+      subscribes :run, "file[#{home_dir}/.sdm/roles]", :delayed
+      subscribes :run, 'ruby_block[register-server]', :delayed
+    end
+  end
+end
+
+action_class do
+  include StrongDM::Helpers
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -30,10 +30,6 @@ describe 'strongdm::default' do
       expect(chef_run).to include_recipe('ark::default')
     end
 
-    it 'creates strongdm user' do
-      expect(chef_run).to create_user('strongdm')
-    end
-
     it 'cherry-picks sdm from ZIP' do
       expect(chef_run).to cherry_pick_ark('sdm')
     end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -27,24 +27,10 @@ describe 'strongdm::server' do
       end.converge(described_recipe)
     end
 
-    it 'runs execute[sdm-admin-add-servers]' do
-      expect(chef_run).to run_execute('sdm-admin-add-servers')
-    end
-
-    it 'creates /opt/strongdm/.sdm' do
-      expect(chef_run).to create_directory('/opt/strongdm/.sdm')
-    end
-
-    it 'creates /opt/strongdm/.ssh' do
-      expect(chef_run).to create_directory('/opt/strongdm/.ssh')
-    end
-
-    it 'creates /opt/strongdm/.ssh/authorized_keys' do
-      expect(chef_run).to create_file('/opt/strongdm/.ssh/authorized_keys')
-    end
-
-    it 'creates /opt/strongdm/.sdm/roles' do
-      expect(chef_run).to create_file('/opt/strongdm/.sdm/roles')
+    it 'creates strongdm SSH configuration' do
+      expect(chef_run).to create_strongdm_server('fauxhai.local').with(
+        granted_roles: []
+      )
     end
 
     it 'converges successfully' do

--- a/test/integration/server/controls/server_spec.rb
+++ b/test/integration/server/controls/server_spec.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: strongdm
-# Recipe:: default
+# Spec:: server
 #
 # Copyright © 2018 Applause App Quality, Inc.
 #
@@ -17,12 +17,10 @@
 # limitations under the License.
 #
 
-include_recipe 'ark'
+describe user('strongdm') do
+  it { should exist }
+end
 
-ark 'sdm' do
-  action :cherry_pick
-  url node['strongdm']['url']
-  path Chef::Config['file_cache_path']
-  extension 'zip'
-  creates 'sdm'
+describe file('/home/strongdm/.ssh/authorized_keys') do
+  it { should exist }
 end


### PR DESCRIPTION
Creates a `strongdm_server` custom resource to be used to register a server
for SSH. This resource will create a user and configure its
`~/.ssh/authorized_keys` with the `strongDM` provided public key.

*** WARNING ***

This removes the user creation from the default recipe and into the resources
which use it.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>