### PR TITLE
Relax ark dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs and configures strongDM'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.5.0'
 
-depends 'ark', '~> 3.1.1'
+depends 'ark'
 
 %w(redhat centos scientific amazon ubuntu debian suse).each do |os|
   supports os


### PR DESCRIPTION
Remove the version constraints on the `ark` cookbook dependency since
this cookbook doesn't rely on specific behavior that requires a specific
version of the cookbook.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>