### PR TITLE
Add missing directory for server registration

### DIFF
--- a/resources/server.rb
+++ b/resources/server.rb
@@ -50,6 +50,12 @@ action :create do
     mode 0700
   end
 
+  directory "#{home_dir}/.sdm" do
+    owner new_resource.user_name
+    group new_resource.user_name
+    mode 0700
+  end
+
   pubkey = 'DO-NOT-MATCH'
   ruby_block 'register-server' do
     block do


### PR DESCRIPTION
This should create `.sdm` directory under the `home_dir` which is needed
for creating the `roles` file