### PR TITLE
Use remote_file/execute instead of ark

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,6 @@ description      'Installs and configures strongDM'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.5.2'
 
-depends 'ark'
-
 %w(redhat centos scientific amazon ubuntu debian suse).each do |os|
   supports os
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: strongdm
 # Recipe:: default
 #
-# Copyright © 2018 Applause App Quality, Inc.
+# Copyright © 2018-2019 Applause App Quality, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,12 +17,14 @@
 # limitations under the License.
 #
 
-include_recipe 'ark'
+package 'unzip'
 
-ark 'sdm' do
-  action :cherry_pick
-  url node['strongdm']['url']
-  path Chef::Config['file_cache_path']
-  extension 'zip'
-  creates 'sdm'
+remote_file "#{Chef::Config['file_cache_path']}/sdm.zip" do
+  source node['strongdm']['url']
+end
+
+execute 'unzip-sdm.zip' do
+  command 'unzip sdm.zip'
+  cwd Chef::Config['file_cache_path']
+  creates "#{Chef::Config['file_cache_path']}/sdm"
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: strongdm
 # Spec:: default
 #
-# Copyright © 2018 Applause App Quality, Inc.
+# Copyright © 2018-2019 Applause App Quality, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,12 +26,16 @@ describe 'strongdm::default' do
       end.converge(described_recipe)
     end
 
-    it 'includes ark recipe' do
-      expect(chef_run).to include_recipe('ark::default')
+    it 'installs unzip' do
+      expect(chef_run).to install_package('unzip')
     end
 
-    it 'cherry-picks sdm from ZIP' do
-      expect(chef_run).to cherry_pick_ark('sdm')
+    it 'downloads sdm.zip' do
+      expect(chef_run).to create_remote_file("#{Chef::Config['file_cache_path']}/sdm.zip")
+    end
+
+    it 'extracts sdm.zip' do
+      expect(chef_run).to run_execute('unzip-sdm.zip')
     end
 
     it 'converges successfully' do


### PR DESCRIPTION
Switch away from using the `ark` cookbook to directly downloading and
extracting the archive into two steps, which will decompress the archive
contents, even if the contents are moved by the sdm install command.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>