### PR TITLE
Use hostname for gateway/relay names

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -22,7 +22,7 @@ module StrongDM
     def sdm_relay_token(admin_token, name, type = 'relay', ip = nil, port = 5000, bind_ip = '0.0.0.0', bind_port = 5000)
       return nil if admin_token.nil?
       ip = node['ipaddress'] if ip.nil?
-      name = node['fqdn'] if name.nil?
+      name = node['hostname'] if name.nil?
       token = Mixlib::ShellOut.new(
         sdm,
         'relay',

--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: strongdm
 # Recipe:: gateway
 #
-# Copyright © 2018 Applause App Quality, Inc.
+# Copyright © 2018-2019 Applause App Quality, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 include_recipe 'strongdm::default'
 
-strongdm_install node['fqdn'] do
+strongdm_install node['hostname'] do
   type 'gateway'
   advertise_address node['strongdm']['gateway_advertise_address']
   bind_address node['strongdm']['gateway_bind_address']

--- a/recipes/relay.rb
+++ b/recipes/relay.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: strongdm
 # Recipe:: relay
 #
-# Copyright © 2018 Applause App Quality, Inc.
+# Copyright © 2018-2019 Applause App Quality, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
 include_recipe 'strongdm::default'
 
-strongdm_install node['fqdn'] do
+strongdm_install node['hostname'] do
   advertise_address node['strongdm']['relay_advertise_address']
   bind_address node['strongdm']['relay_bind_address']
   bind_port node['strongdm']['relay_bind_port']

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: strongdm
 # Resource:: install
 #
-# Copyright © 2018 Applause App Quality, Inc.
+# Copyright © 2018-2019 Applause App Quality, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/spec/gateway_spec.rb
+++ b/spec/gateway_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: strongdm
 # Spec:: gateway
 #
-# Copyright © 2018 Applause App Quality, Inc.
+# Copyright © 2018-2019 Applause App Quality, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ describe 'strongdm::gateway' do
     end
 
     it 'creates sdm gateway install' do
-      expect(chef_run).to create_strongdm_install('fauxhai.local').with(
+      expect(chef_run).to create_strongdm_install('Fauxhai').with(
         type: 'gateway'
       )
     end

--- a/spec/relay_spec.rb
+++ b/spec/relay_spec.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: strongdm
 # Spec:: relay
 #
-# Copyright © 2018 Applause App Quality, Inc.
+# Copyright © 2018-2019 Applause App Quality, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ describe 'strongdm::relay' do
     end
 
     it 'creates sdm relay install' do
-      expect(chef_run).to create_strongdm_install('fauxhai.local').with(
+      expect(chef_run).to create_strongdm_install('Fauxhai').with(
         type: 'relay'
       )
     end


### PR DESCRIPTION
The strongDM UI doesn't allow naming gateway/relays with dots in the
name, so we shouldn't use the FQDN as a name, but rather use the
hostname.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>