### PR TITLE
Short-circuit server resource

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -29,23 +29,19 @@ property :type, [String, Array], default: 'relay'
 property :user_name, [String, Integer], default: 'strongdm'
 
 action :create do
-  admin_token = new_resource.admin_token ? new_resource.admin_token : node['strongdm']['admin_token']
-  ip = new_resource.advertise_address ? new_resource.advertise_address : node.run_state['ipaddress']
+  admin_token = new_resource.admin_token || node['strongdm']['admin_token']
+  ip = new_resource.advertise_address || node.run_state['ipaddress']
   ### TODO: make this pick the correct location
-  home_dir = new_resource.home_dir ? new_resource.home_dir : "/home/#{new_resource.user_name}"
-  relay_token = if new_resource.relay_token
-                  new_resource.relay_token
-                else
-                  sdm_relay_token(
-                    admin_token,
-                    new_resource.instance_name,
-                    new_resource.type,
-                    ip,
-                    new_resource.port,
-                    new_resource.bind_address,
-                    new_resource.bind_port
-                  )
-                end
+  home_dir = new_resource.home_dir || "/home/#{new_resource.user_name}"
+  relay_token = new_resource.relay_token || sdm_relay_token(
+    admin_token,
+    new_resource.instance_name,
+    new_resource.type,
+    ip,
+    new_resource.port,
+    new_resource.bind_address,
+    new_resource.bind_port
+  )
 
   # Sanity check our code
   Chef::Application.fatal!('Unable to fetch SDM_RELAY_TOKEN') if relay_token.nil?


### PR DESCRIPTION
Update the `not_if` section of `register-server` `ruby_block` in the
`server` resource to fail faster on missing/empty `authorized_keys` file
to prevent hitting strongDM API on every evaluation.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>