### PR TITLE
Allow registration failures

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,9 @@
 # Set this however you see fit
 default['strongdm']['admin_token'] = nil
 
+# Allow failures to prevent failing Chef run
+default['strongdm']['ignore_registration_failures'] = false
+
 # Installation user
 default['strongdm']['url'] = 'https://app.strongdm.com/releases/cli/linux'
 default['strongdm']['user'] = 'strongdm'

--- a/recipes/gateway.rb
+++ b/recipes/gateway.rb
@@ -26,5 +26,6 @@ strongdm_install node['hostname'] do
   bind_port node['strongdm']['gateway_bind_port']
   port node['strongdm']['gateway_port']
   user_name node['strongdm']['user']
+  ignore_failure node['strongdm']['ignore_registration_failures']
   action :create
 end

--- a/recipes/relay.rb
+++ b/recipes/relay.rb
@@ -26,5 +26,6 @@ strongdm_install node['hostname'] do
   port node['strongdm']['relay_port']
   user_name node['strongdm']['user']
   type 'relay'
+  ignore_failure node['strongdm']['ignore_registration_failures']
   action :create
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -23,4 +23,5 @@ strongdm_server node['fqdn'] do
   admin_token node['strongdm']['admin_token']
   advertise_address node['ipaddress']
   granted_roles node['strongdm']['default_grant_roles']
+  ignore_failure node['strongdm']['ignore_registration_failures']
 end


### PR DESCRIPTION
Allow registration failures, controlled by attribute, to prevent any
upstream issues with the registration API from failing Chef runs.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>