### PR TITLE
Cleanup guard in strongdm_server resource

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: strongdm
 # Recipe:: server
 #
-# Copyright © 2018 Applause App Quality, Inc.
+# Copyright © 2018-2019 Applause App Quality, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: strongdm
 # Resource:: server
 #
-# Copyright © 2018 Applause App Quality, Inc.
+# Copyright © 2018-2019 Applause App Quality, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,21 +73,12 @@ action :create do
       keyfile.close
     end
     notifies :delete, "file[#{home_dir}/.sdm/roles]", :immediately
+    sensitive true
     not_if do
-      # short-circuits to prevent reaching out to strongdm
-      return false unless ::File.exist?("#{home_dir}/.ssh/authorized_keys")
-      return false if ::File.empty?("#{home_dir}/.ssh/authorized_keys")
-      cmd = Mixlib::ShellOut.new(
+      Mixlib::ShellOut.new(
         sdm, 'admin', 'servers', 'list',
         'environment' => { 'SDM_ADMIN_TOKEN' => admin_token }
-      )
-      # do sdm admin servers list
-      cmd.run_command
-      if cmd.exitstatus == 0 && cmd.stdout.chomp.include?(node['fqdn'])
-        true
-      else
-        false
-      end
+      ).run_command.stdout.chomp.include?(node['fqdn'])
     end
   end
 


### PR DESCRIPTION
Previously, we attempted to guard against reaching out to the strongDM
API on each Chef run. Since we now allow ignoring errors, this shouldn't
be as problematic. Clean up the guard to be simpler, but require
external connectivity.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>