### PR TITLE
Fix #34 by using new_resource.instance_name

### DIFF
--- a/resources/server.rb
+++ b/resources/server.rb
@@ -78,7 +78,7 @@ action :create do
       Mixlib::ShellOut.new(
         sdm, 'admin', 'servers', 'list',
         'environment' => { 'SDM_ADMIN_TOKEN' => admin_token }
-      ).run_command.stdout.chomp.include?(node['fqdn'])
+      ).run_command.stdout.chomp.include?(new_resource.instance_name)
     end
   end
 


### PR DESCRIPTION
Fix for issue #34 just using the property instead of node['fqdn'] if someone wants to register the nodes with something else. 